### PR TITLE
added in option to not strip conditional comments

### DIFF
--- a/htmlmin/commands.py
+++ b/htmlmin/commands.py
@@ -12,10 +12,15 @@ def main():
     parser = argparse.ArgumentParser(description=u'Minify content of HTML files')
     parser.add_argument('filename', metavar='filename', type=str, nargs=1)
     parser.add_argument('--keep-comments', action='store_true')
+    parser.add_argument('--keep-conditional-comments', action='store_true')
     args = parser.parse_args()
 
     content = ""
     with open(os.path.join(my_dir, args.filename[0])) as html_file:
         content = html_file.read()
 
-    print html_minify(content, ignore_comments=not args.keep_comments)
+    print html_minify(
+            content,
+            ignore_comments=not args.keep_comments,
+            ignore_conditional_comments=not args.keep_conditional_comments
+        )

--- a/htmlmin/tests/resources/with_conditional_comments.html
+++ b/htmlmin/tests/resources/with_conditional_comments.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+    <head>
+        <meta charset="utf-8">
+        <title>Page Title</title>
+    </head>
+
+    <body>
+        <!--[if IE]> this conditional comment should be included, because I like it! <![endif]-->
+        <h1>Header</h1>
+    </body>
+</html>

--- a/htmlmin/tests/resources/with_conditional_comments_minified.html
+++ b/htmlmin/tests/resources/with_conditional_comments_minified.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html lang="pt-BR"><head><meta charset="utf-8" /><title>Page Title</title></head><body><!--[if IE]> this conditional comment should be included, because I like it! <![endif]--><h1>Header</h1></body></html>

--- a/htmlmin/tests/resources/with_conditional_comments_to_exclude.html
+++ b/htmlmin/tests/resources/with_conditional_comments_to_exclude.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+    <head>
+        <meta charset="utf-8">
+        <title>Page Title</title>
+    </head>
+
+    <body>
+        <!--[if IE]> this conditional comment should be included, because I like it! <![endif]-->
+        <h1>Header</h1>
+    </body>
+</html>

--- a/htmlmin/tests/resources/with_conditional_comments_to_exclude_minified.html
+++ b/htmlmin/tests/resources/with_conditional_comments_to_exclude_minified.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html lang="pt-BR"><head><meta charset="utf-8" /><title>Page Title</title></head><body><h1>Header</h1></body></html>

--- a/htmlmin/tests/resources/with_multiple_line_conditional_comments.html
+++ b/htmlmin/tests/resources/with_multiple_line_conditional_comments.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+    <head>
+        <meta charset="utf-8">
+        <title>Page Title</title>
+    </head>
+
+    <body>
+        <!--[if IE] this conditional comment should be exclude, because I didn't like it!
+            But is important to know that it is not so easy.
+
+            Because this comment is bigger.
+        <![endif]-->
+        <h1>Header</h1>
+    </body>
+</html>

--- a/htmlmin/tests/resources/with_multiple_line_conditional_comments_minified.html
+++ b/htmlmin/tests/resources/with_multiple_line_conditional_comments_minified.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html lang="pt-BR"><head><meta charset="utf-8" /><title>Page Title</title></head><body><h1>Header</h1></body></html>

--- a/htmlmin/tests/test_minify.py
+++ b/htmlmin/tests/test_minify.py
@@ -75,12 +75,24 @@ class TestMinify(unittest.TestCase):
         html, html_minified = self._get_normal_and_minified_content_from_html_files('with_comments_to_exclude')
         assert_equals(html_minified, html_minify(html))
 
+    def test_should_exclude_conditional_comments_by_default(self):
+        html, html_minified = self._get_normal_and_minified_content_from_html_files('with_conditional_comments_to_exclude')
+        assert_equals(html_minified, html_minify(html))
+
     def test_should_be_able_to_not_exclude_comments(self):
         html, html_minified = self._get_normal_and_minified_content_from_html_files('with_comments')
         assert_equals(html_minified, html_minify(html, ignore_comments=False))
 
+    def test_should_be_able_to_not_exclude_conditional_comments(self):
+        html, html_minified = self._get_normal_and_minified_content_from_html_files('with_conditional_comments')
+        assert_equals(html_minified, html_minify(html, ignore_comments=False, ignore_conditional_comments=False))
+
     def test_should_be_able_to_exclude_multiline_comments(self):
         html, html_minified = self._get_normal_and_minified_content_from_html_files('with_multiple_line_comments')
+        assert_equals(html_minified, html_minify(html))
+
+    def test_should_be_able_to_exclude_multiline_conditional_comments(self):
+        html, html_minified = self._get_normal_and_minified_content_from_html_files('with_multiple_line_conditional_comments')
         assert_equals(html_minified, html_minify(html))
 
     def test_should_be_able_to_exclude_multiple_comments_on_a_page(self):

--- a/htmlmin/util.py
+++ b/htmlmin/util.py
@@ -2,6 +2,10 @@
 # Copyright 2012 django-htmlmin authors. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
+import re
+import HTMLParser
+from BeautifulSoup import NavigableString, DEFAULT_OUTPUT_ENCODING
+
 
 def force_decode(string, encoding="utf-8"):
     for c in (encoding, "utf-8", "latin-1"):
@@ -14,3 +18,15 @@ def between_two_tags(current_line, all_lines, index):
     if current_line and not current_line.startswith('<') and not all_lines[index-1].endswith('>'):
         return False
     return True
+
+def fix_conditional_comments(string):
+    result = re.compile('<!--\[if (.*)](.*)!\[endif\]-->').match(string)
+    if not result:
+        return string
+    encoded_string = result.group(2)
+    parser = HTMLParser.HTMLParser()
+    return string.replace(encoded_string, parser.unescape(encoded_string))
+
+class ConditionalComment(NavigableString):
+    def __str__(self, encoding=DEFAULT_OUTPUT_ENCODING):
+        return "<!--[if %s<![endif]-->" % NavigableString.__str__(self, encoding)


### PR DESCRIPTION
I have attempted to add in the option to not strip conditional comments (the only thing i think is missing from this project)

BeautifulSoup doesn't seem to like conditional comments and ends up re-encoding the data between the two comments, hence the use of the `fix_conditional_comments` function

I think the only other thing i have missed in the django settings/integration but i just wanted to put this in to make sure its the right approach to take.
