### PR TITLE
Solves the problem of breaking the CSS and Javascript.

### DIFF
--- a/htmlmin/minify.py
+++ b/htmlmin/minify.py
@@ -8,6 +8,8 @@ import re
 
 import bs4
 
+from HTMLParser import HTMLParser
+
 from .util import force_decode, between_two_tags
 
 EXCLUDE_TAGS = ("pre", "script", "textarea",)
@@ -62,6 +64,6 @@ def html_minify(html_code, ignore_comments=True):
 
     for tag in EXCLUDE_TAGS:
         for index, e in enumerate(exclude_tags[tag]):
-            content = content.replace(TAGS_PATTERN % (tag, index, tag), e)
+            content = content.replace(TAGS_PATTERN % (tag, index, tag), HTMLParser().unescape(e))
 
     return content


### PR DESCRIPTION
I used the HTMLParser().unescape() in the exclued tags returning HTML.

```
content = content.replace(TAGS_PATTERN % (tag, index, tag),
                                         HTMLParser().unescape(e)) 
```
