### PR TITLE
Try to fail silently on Soup attribute errors

### DIFF
--- a/htmlmin/minify.py
+++ b/htmlmin/minify.py
@@ -52,7 +52,7 @@ def space_minify(soup, ignore_comments=True):
     :type ignore_comments: bool
     """
     # if tag excluded from minification, just pass
-    if str(soup.name) in EXCLUDE_TAGS:
+    if str(getattr(soup, 'name', '')) in EXCLUDE_TAGS:
         return
 
     # loop through childrens of this element
@@ -154,12 +154,12 @@ def is_inflow(soup):
     :type soup: bs4.BeautifulSoup
     """
     if soup.previous_sibling is not None and \
-        soup.previous_sibling.name in TEXT_FLOW:
+        getattr(soup.previous_sibling, 'name', None) in TEXT_FLOW:
         prev_flow = True
     else:
         prev_flow = False
     if soup.next_sibling is not None and \
-        soup.next_sibling.name in TEXT_FLOW:
+        getattr(soup.next_sibling, 'name', None) in TEXT_FLOW:
         next_flow = True
     else:
         next_flow = False


### PR DESCRIPTION
I was getting errors like the following when trying to minify a few email templates within celery tasks (to avoid clipping by GMail). 

`AttributeError: 'NavigableString' object has no attribute 'name'`
`AttributeError: 'Comment' object has no attribute 'name'`

Tried to silence these errors by using `getattr`, so in the worst case, we're failing silently instead of blowing up. 
