### PR TITLE
Modify whitespace regex to keep non-breaking spaces

### DIFF
--- a/htmlmin/minify.py
+++ b/htmlmin/minify.py
@@ -19,11 +19,12 @@ TEXT_FLOW = set(["a", "em", "strong", "small", "s", "cite", "q", "dfn", "abbr", 
 # fold the doctype element, if True then no newline is added after the
 # doctype element. If False, a newline will be insterted
 FOLD_DOCTYPE = True
-re_multi_space = re.compile(r'\s+', re.MULTILINE|re.UNICODE)
+re_space = u'((?=\\s)[^\xa0])'
+re_multi_space = re.compile(re_space + '+', re.MULTILINE|re.UNICODE)
 re_single_nl = re.compile(r'^\n$', re.MULTILINE|re.UNICODE)
-re_only_space = re.compile(r'^\s+$', re.MULTILINE|re.UNICODE)
-re_start_space = re.compile(r'^\s+', re.MULTILINE|re.UNICODE)
-re_end_space = re.compile(r'\s+$', re.MULTILINE|re.UNICODE)
+re_only_space = re.compile(r'^' + re_space + r'+$', re.MULTILINE|re.UNICODE)
+re_start_space = re.compile(r'^' + re_space + '+', re.MULTILINE|re.UNICODE)
+re_end_space = re.compile(re_space + r'+$', re.MULTILINE|re.UNICODE)
 # see http://en.wikipedia.org/wiki/Conditional_comment
 re_cond_comment = re.compile(r'\[if .*\]>.*<!\[endif\]',
                              re.MULTILINE|re.DOTALL|re.UNICODE)

--- a/htmlmin/tests/test_minify.py
+++ b/htmlmin/tests/test_minify.py
@@ -150,6 +150,12 @@ class TestMinify(unittest.TestCase):
         got_html = html_minify(html)
         self.assertEqual(minified, got_html)
 
+    def test_should_keep_non_breaking_space(self):
+        html = '<html><head></head><body>This is seperated&nbsp;by a non breaking space.</body></html>'
+        minified = u'<html><head></head><body>This is seperated\xa0by a non breaking space.</body></html>'
+        got_html = html_minify(html)
+        self.assertEqual(minified, got_html)
+
     def test_non_ascii(self):
         html, minified = self._normal_and_minified('non_ascii')
         self.assertEqual(minified, html_minify(html))


### PR DESCRIPTION
As noted in issue #83, django-htmlmin currently removes ``&nbsp;``. Normally, a programmer would expect that ``&nbsp;`` characters would be kept, as they are normally put into a document for a reason.

To keep the character, I modified the regex that is used to recognize whitespace. I had to use a lookahead regex expression in order to still profit from python's built-in ``\s`` constant.

Please note that the minified HTML will contain the Unicode character ``\xA0`` instead of ``&nbsp;``. This is because of BeautifulSoup's HTML rendering is consistent with the behaviour for other HTML entities.