### PR TITLE
Added support for Python 3 and 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 dist/
 *.egg-info/
 .ropeproject
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.2"
+  - "3.4"
 install: make dependencies
 script: make test

--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Jamil Atta Junior <atta.jamil@gmail.com>
 Leon Smith <leonsmith000@gmail.com>
 Matthias Bauer <matthias.bauer@intosite.de>
 Mystic-Mirage <mm@m10e.net>
+Younes Zakaria <yz@imgmix.com>

--- a/htmlmin/__init__.py
+++ b/htmlmin/__init__.py
@@ -2,4 +2,4 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'

--- a/htmlmin/commands.py
+++ b/htmlmin/commands.py
@@ -12,7 +12,7 @@ my_dir = os.getcwd()
 
 def main():
     parser = argparse.ArgumentParser(
-        description=u('Minify content of HTML files'),
+        description=six.u('Minify content of HTML files'),
     )
     parser.add_argument('filename', metavar='filename', type=str, nargs=1)
     parser.add_argument('--keep-comments', action='store_true')

--- a/htmlmin/commands.py
+++ b/htmlmin/commands.py
@@ -4,6 +4,7 @@
 
 import argparse
 import os
+import six
 from htmlmin.minify import html_minify
 
 my_dir = os.getcwd()
@@ -11,7 +12,7 @@ my_dir = os.getcwd()
 
 def main():
     parser = argparse.ArgumentParser(
-        description=u'Minify content of HTML files',
+        description=u('Minify content of HTML files'),
     )
     parser.add_argument('filename', metavar='filename', type=str, nargs=1)
     parser.add_argument('--keep-comments', action='store_true')
@@ -21,4 +22,4 @@ def main():
     with open(os.path.join(my_dir, args.filename[0])) as html_file:
         content = html_file.read()
 
-    print html_minify(content, ignore_comments=not args.keep_comments)
+    print(html_minify(content, ignore_comments=not args.keep_comments))

--- a/htmlmin/minify.py
+++ b/htmlmin/minify.py
@@ -5,7 +5,7 @@
 # license that can be found in the LICENSE file.
 
 import re
-
+import six
 import bs4
 
 from .util import force_decode
@@ -19,7 +19,7 @@ TEXT_FLOW = set(["a", "em", "strong", "small", "s", "cite", "q", "dfn", "abbr", 
 # fold the doctype element, if True then no newline is added after the
 # doctype element. If False, a newline will be insterted
 FOLD_DOCTYPE = True
-re_space = u'((?=\\s)[^\xa0])'
+re_space = u('((?=\\s)[^\xa0])')
 re_multi_space = re.compile(re_space + '+', re.MULTILINE|re.UNICODE)
 re_single_nl = re.compile(r'^\n$', re.MULTILINE|re.UNICODE)
 re_only_space = re.compile(r'^' + re_space + r'+$', re.MULTILINE|re.UNICODE)
@@ -40,8 +40,8 @@ def html_minify(html_code, ignore_comments=True, parser="html5lib"):
     mini_soup = space_minify(soup, ignore_comments)
     if FOLD_DOCTYPE is True:
         # monkey patching to remove new line after doctype
-        bs4.element.Doctype.SUFFIX = u'>'
-    return unicode(mini_soup)
+        bs4.element.Doctype.SUFFIX = u('>')
+    return u(mini_soup)
 
 def space_minify(soup, ignore_comments=True):
     """recursive function to reduce space characters in html code.
@@ -105,7 +105,7 @@ def space_minify(soup, ignore_comments=True):
         # conditional comment and
         elif ignore_comments == True and is_comment(soup):
             # remove the element
-            soup.string.replace_with(u'')
+            soup.string.replace_with(u(''))
     return soup
 
 def is_navstr(soup):

--- a/htmlmin/minify.py
+++ b/htmlmin/minify.py
@@ -19,7 +19,7 @@ TEXT_FLOW = set(["a", "em", "strong", "small", "s", "cite", "q", "dfn", "abbr", 
 # fold the doctype element, if True then no newline is added after the
 # doctype element. If False, a newline will be insterted
 FOLD_DOCTYPE = True
-re_space = u('((?=\\s)[^\xa0])')
+re_space = six.u('((?=\\s)[^\xa0])')
 re_multi_space = re.compile(re_space + '+', re.MULTILINE|re.UNICODE)
 re_single_nl = re.compile(r'^\n$', re.MULTILINE|re.UNICODE)
 re_only_space = re.compile(r'^' + re_space + r'+$', re.MULTILINE|re.UNICODE)
@@ -40,8 +40,8 @@ def html_minify(html_code, ignore_comments=True, parser="html5lib"):
     mini_soup = space_minify(soup, ignore_comments)
     if FOLD_DOCTYPE is True:
         # monkey patching to remove new line after doctype
-        bs4.element.Doctype.SUFFIX = u('>')
-    return u(mini_soup)
+        bs4.element.Doctype.SUFFIX = six.u('>')
+    return six.u(mini_soup)
 
 def space_minify(soup, ignore_comments=True):
     """recursive function to reduce space characters in html code.
@@ -105,7 +105,7 @@ def space_minify(soup, ignore_comments=True):
         # conditional comment and
         elif ignore_comments == True and is_comment(soup):
             # remove the element
-            soup.string.replace_with(u(''))
+            soup.string.replace_with(six.u(''))
     return soup
 
 def is_navstr(soup):

--- a/htmlmin/minify.py
+++ b/htmlmin/minify.py
@@ -41,7 +41,10 @@ def html_minify(html_code, ignore_comments=True, parser="html5lib"):
     if FOLD_DOCTYPE is True:
         # monkey patching to remove new line after doctype
         bs4.element.Doctype.SUFFIX = six.u('>')
-    return six.u(mini_soup)
+    if six.PY2:
+        return unicode(mini_soup)
+    else:
+        return mini_soup
 
 def space_minify(soup, ignore_comments=True):
     """recursive function to reduce space characters in html code.

--- a/htmlmin/tests/test_minify.py
+++ b/htmlmin/tests/test_minify.py
@@ -79,7 +79,7 @@ class TestMinify(unittest.TestCase):
     def test_minify_function_should_return_a_unicode_object(self):
         html = "<html>   <body>some text here</body>    </html>"
         minified = html_minify(html)
-        if PY2:
+        if six.PY2:
             self.assertEqual(unicode, type(minified))
         else:
             self.assertEqual(str, type(minified))

--- a/htmlmin/tests/test_minify.py
+++ b/htmlmin/tests/test_minify.py
@@ -4,6 +4,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+import six
 import codecs
 import unittest
 
@@ -78,7 +79,10 @@ class TestMinify(unittest.TestCase):
     def test_minify_function_should_return_a_unicode_object(self):
         html = "<html>   <body>some text here</body>    </html>"
         minified = html_minify(html)
-        self.assertEqual(unicode, type(minified))
+        if PY2:
+            self.assertEqual(unicode, type(minified))
+        else:
+            self.assertEqual(str, type(minified))
 
     def test_minify_should_respect_encoding(self):
         html, minified = self._normal_and_minified('blogpost')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ argparse
 django==1.5.5
 beautifulsoup4
 html5lib
+six


### PR DESCRIPTION
I've refactored the unicode literals so that it supports both Python 2 and Python 3. I used 'six' just to keep the codebase a little cleaner, I hope that's okay.

However, there are some known issues, which I hope you guys know how to fix:

Even though it passes the tests on Python 2.x, it fails to even run the tests on Python 3. This is because nosedjango does not support Python 3, which causes Travis to stop the builds on Python 3.x. Though our code should (theoretically) work on Python 3 now.

Is there any idea on how we can fix that? The guys over at nosedjango seems pretty dead.