### PR TITLE
Avoid KeyError if no Content-Type header; don't perform unnecessary checks in can_minify_response

### DIFF
--- a/htmlmin/middleware.py
+++ b/htmlmin/middleware.py
@@ -28,14 +28,13 @@ class HtmlMinifyMiddleware(object):
             for url_pattern in settings.EXCLUDE_FROM_MINIFYING:
                 regex = re.compile(url_pattern)
                 if regex.match(request.path.lstrip('/')):
-                    req_ok = False
-                    break
+                    return False
 
         resp_ok = response.status_code == 200
         resp_ok = resp_ok and 'text/html' in response['Content-Type']
         if hasattr(response, 'minify_response'):
             resp_ok = resp_ok and response.minify_response
-        return req_ok and resp_ok
+        return resp_ok
 
     def process_response(self, request, response):
         minify = getattr(settings, "HTML_MINIFY", not settings.DEBUG)

--- a/htmlmin/middleware.py
+++ b/htmlmin/middleware.py
@@ -20,6 +20,9 @@ class HtmlMinifyMiddleware(object):
             req_ok = request._hit_htmlmin
         except AttributeError:
             return False
+        else:
+            if not req_ok:
+                raise ValueError("`request._hit_htmlmin` was set to False, when should only be True or not set.")
 
         if hasattr(settings, 'EXCLUDE_FROM_MINIFYING'):
             for url_pattern in settings.EXCLUDE_FROM_MINIFYING:

--- a/htmlmin/middleware.py
+++ b/htmlmin/middleware.py
@@ -31,7 +31,7 @@ class HtmlMinifyMiddleware(object):
                     return False
 
         resp_ok = response.status_code == 200
-        resp_ok = resp_ok and 'text/html' in response['Content-Type']
+        resp_ok = resp_ok and 'text/html' in response.get('Content-Type', '')
         if hasattr(response, 'minify_response'):
             resp_ok = resp_ok and response.minify_response
         return resp_ok

--- a/htmlmin/tests/test_middleware.py
+++ b/htmlmin/tests/test_middleware.py
@@ -197,6 +197,18 @@ class TestMiddleware(unittest.TestCase):
                 request_mock, ResponseMock(),
             )
 
+    def test_does_not_throw_error_when_no_content_type_set(self):
+        response_mock = ResponseMock()
+        if 'Content-Type' in response_mock:
+            del response_mock['Content-Type']
+
+        # no self.assertNotRaises exists, but failing test would raise
+        #  a KeyError
+        response = HtmlMinifyMiddleware().process_response(
+            RequestMock(), response_mock,
+        )
+
+
     def test_should_not_minify_when_request_did_not_hit_middleware(self):
         expected_output = "<html>   <body>some text here</body>    </html>"
 

--- a/htmlmin/tests/test_middleware.py
+++ b/htmlmin/tests/test_middleware.py
@@ -189,6 +189,14 @@ class TestMiddleware(unittest.TestCase):
         MarkRequestMiddleware().process_request(request_mock)
         self.assertTrue(request_mock._hit_htmlmin)
 
+    def test_should_never_set_flag_to_false(self):
+        request_mock = RequestBareMock()
+        request_mock._hit_htmlmin = False
+        with self.assertRaises(ValueError):
+            response = HtmlMinifyMiddleware().process_response(
+                request_mock, ResponseMock(),
+            )
+
     def test_should_not_minify_when_request_did_not_hit_middleware(self):
         expected_output = "<html>   <body>some text here</body>    </html>"
 


### PR DESCRIPTION
When using `django-htmlmin` in my project, I found that some responses were being returned without the `Content-Type` header. Even though I was excluding those URLs from being minified using the settings.py `EXCLUDE_FROM_MINIFYING` option, the structure of the middleware's `can_minify_response` function did two things that resulted in errors:

1. Even after determining via the RegEx check that the URL should be excluded from minification, it continued to perform additional checks that included the error-containing code, and
2. The check for the `Content-Type` header in the `request` dictionary would throw a `KeyError` if the header wasn't present.

I've fixed both of those issues, as well as adding an additional test in case `request._hit_htmlmin` is ever set to `False` (which it shouldn't be, so why not have a test for it?)