### PR TITLE
fixes Content-Length after content change

### DIFF
--- a/htmlmin/middleware.py
+++ b/htmlmin/middleware.py
@@ -42,4 +42,6 @@ class HtmlMinifyMiddleware(object):
             response.content = html_minify(response.content,
                                            ignore_comments=not keep_comments,
                                            parser=parser)
+            if response.get('Content-Length', None):
+                response['Content-Length'] = len(response.content)
         return response

--- a/htmlmin/tests/test_middleware.py
+++ b/htmlmin/tests/test_middleware.py
@@ -7,6 +7,8 @@ import sys
 import unittest
 
 from django.conf import settings
+from django.middleware.http import ConditionalGetMiddleware
+from django.http.response import HttpResponse
 from htmlmin.middleware import HtmlMinifyMiddleware, MarkRequestMiddleware
 from htmlmin.tests import TESTS_DIR
 from htmlmin.tests.mocks import (RequestBareMock, RequestMock, ResponseMock,
@@ -199,3 +201,11 @@ class TestMiddleware(unittest.TestCase):
             request_mock, ResponseMock(),
         )
         self.assertEqual(expected_output, response.content)
+
+    def test_should_return_correct_content_length_header_after_minify(self):
+        content_input = "<html>   <body>some text here</body>    </html>"
+
+        request_mock = RequestMock()
+        response = ConditionalGetMiddleware().process_response(request_mock, HttpResponse(content_input))
+        response = HtmlMinifyMiddleware().process_response(request_mock, response)
+        self.assertEqual(int(response['Content-Length']), len(response.content))


### PR DESCRIPTION
With Django 1.7.x and django-htmlmin fails with infinity loop
