### PR TITLE
Disable minifying for AJAX requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ You can also optionally specify the ``HTML_MINIFY_AJAX`` setting:
     HTML_MINIFY_AJAX = False
 
 The default value for the ``HTML_MINIFY_AJAX`` setting is ``True``. You only
-need to set it to ``True`` if don't want to minify AJAX requests.
+need to set it to ``False`` if don't want to minify AJAX requests.
 
 Excluding some URLs
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,16 @@ The default value for the ``HTML_MINIFY`` setting is ``not DEBUG``. You only
 need to set it to ``True`` if you want to minify your HTML code when ``DEBUG``
 is enabled.
 
+You can also optionally specify the ``HTML_MINIFY_AJAX`` setting:
+
+
+.. code-block:: python
+
+    HTML_MINIFY_AJAX = False
+
+The default value for the ``HTML_MINIFY_AJAX`` setting is ``True``. You only
+need to set it to ``True`` if don't want to minify AJAX requests.
+
 Excluding some URLs
 -------------------
 

--- a/htmlmin/middleware.py
+++ b/htmlmin/middleware.py
@@ -50,6 +50,9 @@ class HtmlMinifyMiddleware(object):
                 if regex.match(request.path.lstrip('/')):
                     req_ok = False
                     break
+			
+	if not getattr(settings, 'HTML_MINIFY_AJAX', True) and request.is_ajax():
+            return False
 
         resp_ok = 'text/html' in response.get('Content-Type', '')
         if hasattr(response, 'minify_response'):

--- a/htmlmin/middleware.py
+++ b/htmlmin/middleware.py
@@ -51,7 +51,7 @@ class HtmlMinifyMiddleware(object):
                     req_ok = False
                     break
 			
-	if not getattr(settings, 'HTML_MINIFY_AJAX', True) and request.is_ajax():
+        if not getattr(settings, 'HTML_MINIFY_AJAX', True) and request.is_ajax():
             return False
 
         resp_ok = 'text/html' in response.get('Content-Type', '')


### PR DESCRIPTION
Add setting `HTML_MINIFY_AJAX = True/False` to turn off minifying and adding html tags to AJAX requests.