### PR TITLE
Django 11 compatibilty

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Leon Smith <leonsmith000@gmail.com>
 Matthias Bauer <matthias.bauer@intosite.de>
 Mystic-Mirage <mm@m10e.net>
 Younes Zakaria <yz@imgmix.com>
+Marcel Mulder <memulder@greensoter.com>

--- a/htmlmin/__init__.py
+++ b/htmlmin/__init__.py
@@ -4,4 +4,4 @@ Use of this source code is governed by a BSD-style
 license that can be found in the LICENSE file.
 """
 
-__version__ = '0.10.0'
+__version__ = '0.11.0'

--- a/htmlmin/middleware.py
+++ b/htmlmin/middleware.py
@@ -5,6 +5,7 @@
 import re
 
 from django.conf import settings
+
 from htmlmin.minify import html_minify
 
 
@@ -64,4 +65,5 @@ class HtmlMinifyMiddleware(object):
             response.content = html_minify(response.content,
                                            ignore_comments=not keep_comments,
                                            parser=parser)
+            response['Content-Length'] = len(response.content)
         return response

--- a/htmlmin/tests/pico_django.py
+++ b/htmlmin/tests/pico_django.py
@@ -10,7 +10,7 @@ Description: Code based on snippet available in the link below.
     https://github.com/readevalprint/mini-django/blob/master/pico_django.py
 '''
 
-from django.conf.urls import patterns
+from django.conf.urls import url
 from django.http import HttpResponse
 from htmlmin.decorators import minified_response, not_minified_response
 
@@ -38,7 +38,9 @@ def not_minified(request):
 def raw(request):
     return HttpResponse(CONTENT)
 
-urlpatterns = patterns('',
-                       (r'^min$', minified),
-                       (r'^raw$', raw),
-                       (r'^not_min$', not_minified))
+
+urlpatterns = [
+    url(r'^min$', minified),
+    url(r'^raw$', raw),
+    url(r'^not_min$', not_minified)
+]

--- a/htmlmin/tests/test_middleware.py
+++ b/htmlmin/tests/test_middleware.py
@@ -199,3 +199,12 @@ class TestMiddleware(unittest.TestCase):
             request_mock, ResponseMock(),
         )
         self.assertEqual(expected_output, response.content)
+
+    def test_content_length_header_should_contain_minified_size(self):
+        response_mock = ResponseMock()
+        response = HtmlMinifyMiddleware().process_response(
+            RequestMock(), response_mock,
+        )
+
+        minified = "<html><head></head><body>some text here</body></html>"
+        self.assertEqual(len(minified), response['Content-Length'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 argparse
-django==1.9.6
+django==1.11.11
 beautifulsoup4
 html5lib
-six==1.10.0
-tox==2.4.1
+six==1.11.0
+tox==2.9.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35
+envlist = py27,py34
 [testenv]
 setenv =
     PYTHONPATH=.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34
+envlist = py27,py35
 [testenv]
 setenv =
     PYTHONPATH=.


### PR DESCRIPTION
Updated to be compatible with django 1.11
Tests updated to run against django 1.11. Tests are not run against previous django versions. So compatibility with previous versions is not assured.