### PR TITLE
Migrate from travis-ci to GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 99

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,31 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  run-tests:
+    name: run-tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "2.7.x"
+          - "3.6.x"
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - uses: actions/setup-python@v2.2.1
+        with:
+          python-version: "${{ matrix.python-version }}"
+
+      - run: make dependencies
+
+      - run: make test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,4 +28,4 @@ jobs:
 
       - run: make dependencies
 
-      - run: make test
+      - run: make runtests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: python
-sudo: false
-python:
-  - "2.7"
-  - "3.6"
-install:
-  - pip install -U setuptools
-  - make dependencies
-script: make test

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,14 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+.PHONY: dependencies
 dependencies:
 	@pip install -r requirements.txt
 
+.PHONY: clean
 clean:
 	@find . -name "*.pyc" -delete
 
+.PHONY: test
 test: dependencies clean
 	@PYTHONPATH=. django-admin.py test --settings htmlmin.tests.mock_settings htmlmin
-

--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,8 @@ clean:
 	@find . -name "*.pyc" -delete
 
 .PHONY: test
-test: dependencies clean
-	@django-admin.py test --settings htmlmin.tests.mock_settings htmlmin
+test: dependencies clean runtests
+
+.PHONY: runtests
+runtests:
+	django-admin.py test --settings htmlmin.tests.mock_settings htmlmin

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ clean:
 
 .PHONY: test
 test: dependencies clean
-	@PYTHONPATH=. django-admin.py test --settings htmlmin.tests.mock_settings htmlmin
+	@django-admin.py test --settings htmlmin.tests.mock_settings htmlmin

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 django-htmlmin
 ++++++++++++++
 
-.. image:: https://secure.travis-ci.org/cobrateam/django-htmlmin.png
-   :target: http://travis-ci.org/cobrateam/django-htmlmin
+.. image:: https://github.com/cobrateam/django-htmlmin/workflows/Build/badge.svg
+   :target: https://github.com/cobrateam/django-htmlmin/actions?query=branch:master+workflow:Build
 
 django-html is an HTML minifier for Python, with full support for HTML 5. It
 supports Django, Flask and many other Python web frameworks. It also provides a

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-argparse
-django==1.11.29
-beautifulsoup4==4.7.1
-html5lib==1.0.1
+-e .[test]
 six==1.12.0
 mock

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ def get_version(package):
         init_py = fp.read()
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
+
 version = get_version('htmlmin')
 
 with open('README.rst', 'r') as fp:
@@ -41,6 +42,9 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=['beautifulsoup4', 'html5lib'],
+    extras_require={
+        'test': tests_require,
+    },
     tests_require=tests_require,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
We should probably drop support for Python 2.x, but that can be done later.

Closes #149.